### PR TITLE
Update example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ export const YourComponent = () => {
       </h3>
 
       <button onClick={acceptAllCookies}>Accept all</button>
-      <button onClick={() => acceptCookies({ thirdParty: true })}>
+      <button onClick={() => acceptCookies({ necessary: true, thirdParty: true })}>
         Accept third-party
       </button>
-      <button onClick={() => acceptCookies({ firstParty: true })}>
+      <button onClick={() => acceptCookies({ necessary: true, firstParty: true })}>
         Accept first-party
       </button>
       <button onClick={declineAllCookies}>Reject all</button>
@@ -87,6 +87,23 @@ export const YourComponent = () => {
   );
 };
 ```
+
+### With custom cookie attributes
+```tsx
+import { useCookieConsent } from '@use-cookie-consent/core';
+
+export const YourComponent = () => {
+  const { consent, acceptAllCookies, declineAllCookies, acceptCookies } = useCookieConsent({ 
+      consentCookieAttributes: { expires: 180  } // 180 days
+    }); 
+
+  return (
+    // ...
+  );
+};
+```
+
+Cookie attributes for the underlying js-cookie package, more info [here](https://github.com/js-cookie/js-cookie).
 
 ## API
 


### PR DESCRIPTION
## Why?
While using the package I followed the example in the README but noticed that was not setting the actual cookie in the browser. After digging I noticed that was because it needs the necessary cookies to be `true` to set the cookie.

https://github.com/use-cookie-consent/use-cookie-consent-core/blob/feeb78cd823b21cb9f626e84526ffcec10b8ef28/src/useCookieConsent.ts#L24-L29

And even when the default value of the necessary cookies is `true`, the initial value does not persist using `acceptCookies()`. The easiest fix was just setting the necessary cookies to `true` along with the new value.

I also added a basic example of the hook with custom cookie attributes.